### PR TITLE
Proper name for downloads button

### DIFF
--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -18,7 +18,7 @@
                     </span>
                 </router-link>
                 <div class="sep"></div>
-                <router-link class="btn" to="/downloads">download client</router-link>
+                <router-link class="btn" to="/downloads">download</router-link>
                 <span class="launch">
                     Before starting, unpack
                     <i>altv.exe</i> to an empty folder.


### PR DESCRIPTION
Since "download client" button refers to both client and server downloads, seems like "download" is better name for a such button